### PR TITLE
Fix missing string conversion of message.move

### DIFF
--- a/keyboardinput.py
+++ b/keyboardinput.py
@@ -47,7 +47,7 @@ class TerminalDisplay(Display, threading.Thread):
                 print('Book move')
             elif message == Message.COMPUTER_MOVE:
                 print('\n' + str(message.game))
-                print('Computer move : ' + message.move)
+                print('Computer move:', message.move)
             elif message == Message.START_NEW_GAME:
                 print('New game')
             elif message == Message.SEARCH_STARTED:


### PR DESCRIPTION
This fixes the following issue:

```
$ ./picochess.py --engine /usr/games/stockfish 
2015-02-16 18:22:51.125 WARNING picochess - main: No DGT board port provided
PicoChess v031:>e2e4
PicoChess v031:>Book move

r n b q k b n r
p p . p p p p p
. . . . . . . .
. . p . . . . .
. . . . P . . .
. . . . . . . .
P P P P . P P P
R N B Q K B N R
Exception in thread Thread-12:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/home/niklas/Projekte/picochess/keyboardinput.py", line 50, in run
    print('Computer move : ' + message.move)
TypeError: Can't convert 'Move' object to str implicitly
```