### PR TITLE
Add 75 move rule and fivefold repetition

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -177,6 +177,12 @@ def main():
         if game.is_insufficient_material():
             Display.show(Message.GAME_ENDS, result=GameResult.INSUFFICIENT_MATERIAL, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
             return False
+        if game.is_seventyfive_moves():
+            Display.show(Message.GAME_ENDS, result=GameResult.SEVENTYFIVE_MOVES, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
+            return False
+        if game.is_fivefold_repetition():
+            Display.show(Message.GAME_ENDS, result=GameResult.FIVEFOLD_REPETITION, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
+            return False
         if game.is_game_over():
             Display.show(Message.GAME_ENDS, result=GameResult.MATE, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
             return False

--- a/utilities.py
+++ b/utilities.py
@@ -131,6 +131,8 @@ class GameResult(enum.Enum):
     STALEMATE = 'stalemate'
     TIME_CONTROL = 'time'
     INSUFFICIENT_MATERIAL = 'material'
+    SEVENTYFIVE_MOVES = '75 moves'
+    FIVEFOLD_REPETITION = 'repetition'
     ABORT = 'abort'
 
 


### PR DESCRIPTION
Picochess does not yet know about the 75 move rule and fivefold repetition as causes for finishing a game. The proposed changes in picochess.py and utilities.py should fix that.