### PR TITLE
adds SMTP delivery of a finished game

### DIFF
--- a/pgn.py
+++ b/pgn.py
@@ -102,14 +102,14 @@ class PgnDisplay(Display, threading.Thread):
                                     logging.debug("SMTP Mail delivery: trying to send email")
                                     conn.sendmail('no-reply@picochess.org', self.email, msg.as_string())
                                     logging.debug("SMTP Mail delivery: successfuly delivered message to SMTP server")
-                                except Exception as exc:
+                                except Exception as exec:
                                     logging.error("SMTP Mail delivery: Failed")
                                     logging.error("SMTP Mail delivery: " + str(exec))
                                 finally:
                                     conn.close()
                                     logging.debug("SMTP Mail delivery: Ended")
-                            except Exception as exc:
-                                logging.error("SMTP Mail delivery2: Failed")
+                            except Exception as exec:
+                                logging.error("SMTP Mail delivery: Failed")
                                 logging.error("SMTP Mail delivery: " + str(exec))
                         # smtp based system end
             except queue.Empty:

--- a/pgn.py
+++ b/pgn.py
@@ -22,15 +22,24 @@ import datetime
 import logging
 import requests
 from utilities import *
+import sys
+import os
+import re
+from email.mime.text import MIMEText
 
 
 class PgnDisplay(Display, threading.Thread):
-    def __init__(self, pgn_file_name, email=None, key=None):
+    def __init__(self, pgn_file_name, email=None, 
+                    fromIniSmtp_Server=None, fromINISmtp_User=None,
+                    fromINISmtp_Pass=None, fromINISmtp_Enc=False):
         super(PgnDisplay, self).__init__()
         self.file_name = pgn_file_name
+        # store information for SMTP based Mail delivery
         self.email = email
-        if email and key:
-            self.key = base64.b64decode(str.encode(key)).decode("utf-8")
+        self.smtp_server = fromIniSmtp_Server
+        self.smtp_encryption = fromINISmtp_Enc
+        self.smtp_user = fromINISmtp_User
+        self.smtp_pass = fromINISmtp_Pass
 
     def run(self):
         while True:
@@ -66,12 +75,42 @@ class PgnDisplay(Display, threading.Thread):
                         file.close()
                     # Send email
                     if self.email:
-                        out = requests.post("https://api.mailgun.net/v2/picochess.org/messages",
-                                            auth=("api", self.key),
-                                            data={"from": "Your PicoChess computer <no-reply@picochess.org>",
-                                            "to": self.email,
-                                            "subject": "Game PGN",
-                                            "text": str(game)})
-                        logging.debug(out)
+
+                        if self.smtp_server: # check if smtp server adress provided
+                            logging.debug("SMTP Mail delivery: Started")
+                            # change to smtp based mail delivery
+                            # depending on encrypted mail delivery, we need to import the right lib
+                            if self.smtp_encryption:
+                                # lib with ssl encryption
+                                logging.debug("SMTP Mail delivery: Import SSL SMTP Lib")
+                                from smtplib import SMTP_SSL as SMTP
+                            else: 
+                                # lib without encryption (SMTP-port 21)
+                                logging.debug("SMTP Mail delivery: Import standard SMTP Lib (no SSL encryption)")
+                                from smtplib import SMTP
+                            try:
+                                msg = MIMEText(str(game), 'plain')  # pack the game to Email body
+                                msg['Subject']= "Game PGN"          # put subject to mail
+                                msg['From'] = "Your PicoChess computer <no-reply@picochess.org>"
+                                logging.debug("SMTP Mail delivery: trying to connect to " + self.smtp_server)
+                                conn = SMTP(self.smtp_server)       # contact smtp server
+                                conn.set_debuglevel(False)          # no debug info from smtp lib
+                                logging.debug("SMTP Mail delivery: trying to log to SMTP Server")
+                                logging.debug("SMTP Mail delivery: Username=" + self.smtp_user + ", Pass=" + self.smtp_pass)
+                                conn.login(self.smtp_user, self.smtp_pass) # login at smtp server
+                                try:
+                                    logging.debug("SMTP Mail delivery: trying to send email")
+                                    conn.sendmail('no-reply@picochess.org', self.email, msg.as_string())
+                                    logging.debug("SMTP Mail delivery: successfuly delivered message to SMTP server")
+                                except Exception as exc:
+                                    logging.error("SMTP Mail delivery: Failed")
+                                    logging.error("SMTP Mail delivery: " + str(exec))
+                                finally:
+                                    conn.close()
+                                    logging.debug("SMTP Mail delivery: Ended")
+                            except Exception as exc:
+                                logging.error("SMTP Mail delivery2: Failed")
+                                logging.error("SMTP Mail delivery: " + str(exec))
+                        # smtp based system end
             except queue.Empty:
                 pass

--- a/picochess.py
+++ b/picochess.py
@@ -69,7 +69,7 @@ def main():
                         format='%(asctime)s.%(msecs)d %(levelname)s %(module)s - %(funcName)s: %(message)s', datefmt="%Y-%m-%d %H:%M:%S")
 
     # Update
-    # update_picochess(args.auto_reboot)
+    update_picochess(args.auto_reboot)
 
     # Load UCI engine
     engine = uci.Engine(args.engine, hostname=args.remote, username=args.user, key_file=args.server_key, password=args.password)

--- a/picochess.py
+++ b/picochess.py
@@ -54,20 +54,22 @@ def main():
     parser.add_argument("-ar", "--auto-reboot", action='store_true', help="reboot system after update")
     parser.add_argument("-web", "--web-server", dest="web_server_port", nargs="?", const=80, type=int, metavar="PORT", help="launch web server")
     parser.add_argument("-mail", "--email", type=str, help="email used to send pgn files", default=None)
-    parser.add_argument("-mk", "--email-key", type=str, help="key used to send emails", default=None)
+    parser.add_argument("-mail_s", "--smtp_server", type=str, help="Adress of email server", default=None)
+    parser.add_argument("-mail_u", "--smtp_user", type=str, help="Username for email server", default=None)
+    parser.add_argument("-mail_p", "--smtp_pass", type=str, help="Password for email server", default=None)
+    parser.add_argument("-mail_enc", "--smtp_encryption", action='store_true', help="use ssl encryption connection to smtp-Server")
     parser.add_argument("-uci", "--uci-option", type=str, help="pass an UCI option to the engine (name;value)", default=None)
     parser.add_argument("-dgt3000", "--dgt-3000-clock", action='store_true', help="use dgt 3000 clock")
     parser.add_argument("-nobeep", "--disable-dgt-clock-beep", action='store_true', help="disable beeps on the dgt clock")
     parser.add_argument("-uvoice", "--user-voice", type=str, help="voice for user", default=None)
     parser.add_argument("-cvoice", "--computer-voice", type=str, help="voice for computer", default=None)
     args = parser.parse_args()
-
     # Enable logging
     logging.basicConfig(filename=args.log_file, level=getattr(logging, args.log_level.upper()),
                         format='%(asctime)s.%(msecs)d %(levelname)s %(module)s - %(funcName)s: %(message)s', datefmt="%Y-%m-%d %H:%M:%S")
 
     # Update
-    update_picochess(args.auto_reboot)
+    # update_picochess(args.auto_reboot)
 
     # Load UCI engine
     engine = uci.Engine(args.engine, hostname=args.remote, username=args.user, key_file=args.server_key, password=args.password)
@@ -95,7 +97,9 @@ def main():
         TerminalDisplay().start()
 
     # Save to PGN
-    PgnDisplay(args.pgn_file, email=args.email, key=args.email_key).start()
+    PgnDisplay(args.pgn_file, email=args.email, 
+                        fromIniSmtp_Server=args.smtp_server, fromINISmtp_User=args.smtp_user,
+                        fromINISmtp_Pass=args.smtp_pass, fromINISmtp_Enc=args.smtp_encryption).start() 
 
     # Create ChessTalker for speech output
     talker = None


### PR DESCRIPTION
Hey friends,

this is my first Python based pull request for PicoChess. :-) Please don't punish me for not so good Python style.

Functional change:
This patch adds the ability to send a finished game via a regular SMTP mail server instead of using Mailgun Webservice. 
It is necessary to enter the options for the SMTP server via picochess.ini or command line. See "picochess.py" for additional required parameters.

Testing:
This patch was tested successfully with internet connection with an SSL and a non-SSL stmp server.
If no internet connection is available the failure of SMTP delivery will only be logged to the logfile but no error is given to the user or any other program interruption. 
I removed the Mailgun service due to not having an access to it. I am pretty sure that both services (Mailgun and SMTP) can stay aside.

Next steps:
If this patch fits to the upstream release of PicoChess an update of documentation is required and will be provided by myself.

Finally:
I hope you like and it works with your installation as well as with mine. 

Best,
Raimar
