### PR TITLE
Restore mailgun mail service

### DIFF
--- a/pgn.py
+++ b/pgn.py
@@ -41,7 +41,7 @@ class PgnDisplay(Display, threading.Thread):
         self.smtp_user = fromINISmtp_User
         self.smtp_pass = fromINISmtp_Pass
         if email and fromINIMailGun_Key:
-            self.mailgun_key = base64.b64decode(str.encode(key)).decode("utf-8")
+            self.mailgun_key = base64.b64decode(str.encode(fromINIMailGun_Key)).decode("utf-8")
 
     def run(self):
         while True:

--- a/pgn.py
+++ b/pgn.py
@@ -41,7 +41,7 @@ class PgnDisplay(Display, threading.Thread):
         self.smtp_user = fromINISmtp_User
         self.smtp_pass = fromINISmtp_Pass
         if email and fromINIMailGun_Key:
-            self.gunmail_key = base64.b64decode(str.encode(key)).decode("utf-8")
+            self.mailgun_key = base64.b64decode(str.encode(key)).decode("utf-8")
 
     def run(self):
         while True:
@@ -113,9 +113,9 @@ class PgnDisplay(Display, threading.Thread):
                                 logging.error("SMTP Mail delivery: Failed")
                                 logging.error("SMTP Mail delivery: " + str(exec))
                         # smtp based system end
-                        if self.gunmail_key:
+                        if self.mailgun_key:
                             out = requests.post("https://api.mailgun.net/v2/picochess.org/messages",
-                                            auth=("api", self.key),
+                                            auth=("api", self.mailgun_key),
                                             data={"from": "Your PicoChess computer <no-reply@picochess.org>",
                                             "to": self.email,
                                             "subject": "Game PGN",

--- a/pgn.py
+++ b/pgn.py
@@ -29,7 +29,7 @@ from email.mime.text import MIMEText
 
 
 class PgnDisplay(Display, threading.Thread):
-    def __init__(self, pgn_file_name, email=None, 
+    def __init__(self, pgn_file_name, email=None, fromINIMailGun_Key=None,
                     fromIniSmtp_Server=None, fromINISmtp_User=None,
                     fromINISmtp_Pass=None, fromINISmtp_Enc=False):
         super(PgnDisplay, self).__init__()
@@ -40,6 +40,8 @@ class PgnDisplay(Display, threading.Thread):
         self.smtp_encryption = fromINISmtp_Enc
         self.smtp_user = fromINISmtp_User
         self.smtp_pass = fromINISmtp_Pass
+        if email and fromINIMailGun_Key:
+            self.gunmail_key = base64.b64decode(str.encode(key)).decode("utf-8")
 
     def run(self):
         while True:
@@ -75,7 +77,6 @@ class PgnDisplay(Display, threading.Thread):
                         file.close()
                     # Send email
                     if self.email:
-
                         if self.smtp_server: # check if smtp server adress provided
                             logging.debug("SMTP Mail delivery: Started")
                             # change to smtp based mail delivery
@@ -112,5 +113,13 @@ class PgnDisplay(Display, threading.Thread):
                                 logging.error("SMTP Mail delivery: Failed")
                                 logging.error("SMTP Mail delivery: " + str(exec))
                         # smtp based system end
+                        if self.gunmail_key:
+                            out = requests.post("https://api.mailgun.net/v2/picochess.org/messages",
+                                            auth=("api", self.key),
+                                            data={"from": "Your PicoChess computer <no-reply@picochess.org>",
+                                            "to": self.email,
+                                            "subject": "Game PGN",
+                                            "text": str(game)})
+                            logging.debug(out)
             except queue.Empty:
                 pass

--- a/picochess.py
+++ b/picochess.py
@@ -58,6 +58,7 @@ def main():
     parser.add_argument("-mail_u", "--smtp_user", type=str, help="Username for email server", default=None)
     parser.add_argument("-mail_p", "--smtp_pass", type=str, help="Password for email server", default=None)
     parser.add_argument("-mail_enc", "--smtp_encryption", action='store_true', help="use ssl encryption connection to smtp-Server")
+     parser.add_argument("-mk", "--mailgun-key", type=str, help="key used to send emails via Mailgun Webservice", default=None)
     parser.add_argument("-uci", "--uci-option", type=str, help="pass an UCI option to the engine (name;value)", default=None)
     parser.add_argument("-dgt3000", "--dgt-3000-clock", action='store_true', help="use dgt 3000 clock")
     parser.add_argument("-nobeep", "--disable-dgt-clock-beep", action='store_true', help="disable beeps on the dgt clock")
@@ -97,7 +98,7 @@ def main():
         TerminalDisplay().start()
 
     # Save to PGN
-    PgnDisplay(args.pgn_file, email=args.email, 
+    PgnDisplay(args.pgn_file, email=args.email, fromINIMailGun_Key=args.mailgun_key,
                         fromIniSmtp_Server=args.smtp_server, fromINISmtp_User=args.smtp_user,
                         fromINISmtp_Pass=args.smtp_pass, fromINISmtp_Enc=args.smtp_encryption).start() 
 

--- a/picochess.py
+++ b/picochess.py
@@ -58,7 +58,7 @@ def main():
     parser.add_argument("-mail_u", "--smtp_user", type=str, help="Username for email server", default=None)
     parser.add_argument("-mail_p", "--smtp_pass", type=str, help="Password for email server", default=None)
     parser.add_argument("-mail_enc", "--smtp_encryption", action='store_true', help="use ssl encryption connection to smtp-Server")
-     parser.add_argument("-mk", "--mailgun-key", type=str, help="key used to send emails via Mailgun Webservice", default=None)
+    parser.add_argument("-mk", "--mailgun-key", type=str, help="key used to send emails via Mailgun Webservice", default=None)
     parser.add_argument("-uci", "--uci-option", type=str, help="pass an UCI option to the engine (name;value)", default=None)
     parser.add_argument("-dgt3000", "--dgt-3000-clock", action='store_true', help="use dgt 3000 clock")
     parser.add_argument("-nobeep", "--disable-dgt-clock-beep", action='store_true', help="disable beeps on the dgt clock")


### PR DESCRIPTION
As my first patch already kicked one feature - the Mailgun Web service function, here its back. :-)

Both options are available to the user, either SMTP or Mailgun service. 

This patch should be checked carefully by some user who uses Mailgun mail feature. I can't really test its functionality due to not having access to Mailguns service.

Have fun!
Raimar