### PR TITLE
Don't treat already finished games as "aborted"

### DIFF
--- a/pgn.py
+++ b/pgn.py
@@ -77,11 +77,10 @@ class PgnDisplay(Display, threading.Thread):
                         game.headers["White"] = "PicoChess"
                         game.headers["Black"] = self.email.split('@')[0] if self.email else 'Player'
                     # Save to file
-                    if message.result != GameResult.ABORT:
-                        file = open(self.file_name, "a")
-                        exporter = chess.pgn.FileExporter(file)
-                        game.export(exporter)
-                        file.close()
+                    file = open(self.file_name, "a")
+                    exporter = chess.pgn.FileExporter(file)
+                    game.export(exporter)
+                    file.close()
                     # section send email
                     if self.email: # check if email adress to send the game to is provided
                         if self.smtp_server: # check if smtp server adress provided

--- a/picochess.py
+++ b/picochess.py
@@ -297,7 +297,7 @@ def main():
                 if game.move_stack:
                     logging.debug("Starting a new game")
                     if not game.is_game_over():
-                    	Display.show(Message.GAME_ENDS, result=GameResult.ABORT, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
+                        Display.show(Message.GAME_ENDS, result=GameResult.ABORT, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
                     game = chess.Bitboard()
                     legal_fens = compute_legal_fens(game)
                     time_control.stop()

--- a/picochess.py
+++ b/picochess.py
@@ -296,7 +296,8 @@ def main():
             if case(Event.NEW_GAME):  # User starts a new game
                 if game.move_stack:
                     logging.debug("Starting a new game")
-                    Display.show(Message.GAME_ENDS, result=GameResult.ABORT, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
+                    if not game.is_game_over():
+                    	Display.show(Message.GAME_ENDS, result=GameResult.ABORT, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
                     game = chess.Bitboard()
                     legal_fens = compute_legal_fens(game)
                     time_control.stop()


### PR DESCRIPTION
After a game has finished, it is over. So Picochess should not subsequently treat it as “aborted” when the player put the pieces back to starting position. This commit is meant to fix this issue.