### PR TITLE
Update python-chess to 0.8.1 (closes #67)

### DIFF
--- a/dgt.py
+++ b/dgt.py
@@ -278,7 +278,7 @@ class DGTBoard(Observable, Display, threading.Thread):
         self.clock_lock = asyncio.Lock()
         self.enable_dgt_3000 = enable_dgt_3000
         self.enable_dgt_clock_beep = enable_dgt_clock_beep
-        self.bit_board = chess.Bitboard()
+        self.bit_board = chess.Board()
         self.dgt_clock_menu = Menu.GAME_MENU
         self.last_move = None
         self.last_fen = None
@@ -360,7 +360,7 @@ class DGTBoard(Observable, Display, threading.Thread):
         # fen = str(self.setup_chessboard.fen())
         can_castle = False
         castling_fen = ''
-        bit_board = chess.Bitboard(fen)
+        bit_board = chess.Board(fen)
 
         if bit_board.piece_at(chess.E1) == chess.Piece.from_symbol("K") and bit_board.piece_at(chess.H1) == chess.Piece.from_symbol("R"):
             can_castle = True

--- a/libs/chess/polyglot.py
+++ b/libs/chess/polyglot.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of the python-chess library.
-# Copyright (C) 2012-2014 Niklas Fiekas <niklas.fiekas@tu-clausthal.de>
+# Copyright (C) 2012-2015 Niklas Fiekas <niklas.fiekas@tu-clausthal.de>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -102,11 +102,6 @@ class Reader(object):
         self.seek_entry(0)
         return self
 
-    def __reversed__(self):
-        for i in xrange(self.__entry_count - 1, -1, -1):
-            self.seek_entry(i)
-            yield self.next()
-
     def seek_entry(self, offset, whence=0):
         """
         Seek an entry by its index.
@@ -126,7 +121,7 @@ class Reader(object):
 
         # Do a binary search.
         start = 0
-        end = len(self)
+        end = len(self) - 1
         while end >= start:
             middle = int((start + end) / 2)
 

--- a/libs/chesstalker/chesstalker.py
+++ b/libs/chesstalker/chesstalker.py
@@ -510,7 +510,7 @@ class ChessTalkerVoice():
         is_game_over = game.is_game_over()
         is_insufficient_material = game.is_insufficient_material()
         is_seventyfive_moves = game.is_seventyfive_moves()
-        is_fivefold_repitition = game.is_fivefold_repitition()
+        is_fivefold_repetition = game.is_fivefold_repetition()
         # logging.debug("say_move: POST-move game state: %s", str(game))
         # Pop to the previous game state, so we can determine the pieces on the from/to squares.
         game.pop()
@@ -553,7 +553,7 @@ class ChessTalkerVoice():
                     self.say_draw_seventyfive_moves()
                 elif is_insufficient_material:
                     self.say_draw_insufficient_material()
-                elif is_fivefold_repitition:
+                elif is_fivefold_repetition:
                     self.say_draw_fivefold_repetition()
                 else:
                     self.say_draw()

--- a/picochess.py
+++ b/picochess.py
@@ -186,7 +186,7 @@ def main():
         if game.is_seventyfive_moves():
             Display.show(Message.GAME_ENDS, result=GameResult.SEVENTYFIVE_MOVES, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
             return False
-        if game.is_fivefold_repitition():
+        if game.is_fivefold_repetition():
             Display.show(Message.GAME_ENDS, result=GameResult.FIVEFOLD_REPETITION, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
             return False
         if game.is_game_over():
@@ -194,7 +194,7 @@ def main():
             return False
         return True
 
-    game = chess.Bitboard()  # Create the current game
+    game = chess.Board()  # Create the current game
     legal_fens = compute_legal_fens(game)  # Compute the legal FENs
     book = chess.polyglot.open_reader(get_opening_books()[8][1])  # Default opening book
     interaction_mode = Mode.PLAY_WHITE   # Interaction mode
@@ -283,7 +283,7 @@ def main():
             if case(Event.SETUP_POSITION): # User sets up a position
                 logging.debug("Setting up custom fen: {0}".format(event.fen))
 
-                game = chess.Bitboard(event.fen)
+                game = chess.Board(event.fen)
                 game.custom_fen = event.fen
                 legal_fens = compute_legal_fens(game)
                 time_control.stop()
@@ -298,7 +298,7 @@ def main():
                     logging.debug("Starting a new game")
                     if not game.is_game_over():
                         Display.show(Message.GAME_ENDS, result=GameResult.ABORT, moves=list(game.move_stack), color=game.turn, mode=interaction_mode)
-                    game = chess.Bitboard()
+                    game = chess.Board()
                     legal_fens = compute_legal_fens(game)
                     time_control.stop()
                     time_control.reset()


### PR DESCRIPTION
Relevant changes are:

 * The typo in repetition (was repitition) has been fixed
   (closes #67). Aliases will be dropped in some future
   release.

 * Bitboard was renamed to Board. Aliases will be dropped
   in some future release.

 * Board.san() did not have check or checkmate suffixes
   for castling moves, i.e. Qf7# but not O-O-O#.

 * pgn.GameNode.board() is now cached.

 * An off-by-one error in the polyglot opening book binary
   search has been fixed. This would not have been an issue
   with all but contrived opening books.