### PR TITLE
Engine name in pgn output

### DIFF
--- a/pgn.py
+++ b/pgn.py
@@ -29,7 +29,7 @@ from email.mime.text import MIMEText
 
 
 class PgnDisplay(Display, threading.Thread):
-    def __init__(self, engine_name, pgn_file_name, email=None, fromINIMailGun_Key=None,
+    def __init__(self, pgn_file_name, engine_name, email=None, fromINIMailGun_Key=None,
                     fromIniSmtp_Server=None, fromINISmtp_User=None,
                     fromINISmtp_Pass=None, fromINISmtp_Enc=False):
         super(PgnDisplay, self).__init__()

--- a/pgn.py
+++ b/pgn.py
@@ -29,15 +29,16 @@ from email.mime.text import MIMEText
 
 
 class PgnDisplay(Display, threading.Thread):
-    def __init__(self, pgn_file_name, email=None, fromINIMailGun_Key=None,
+    def __init__(self, engine_name, pgn_file_name, email=None, fromINIMailGun_Key=None,
                     fromIniSmtp_Server=None, fromINISmtp_User=None,
                     fromINISmtp_Pass=None, fromINISmtp_Enc=False):
         super(PgnDisplay, self).__init__()
         self.file_name = pgn_file_name
+        self.engine_name = engine_name
         
-        if email: # check if email adress is provided by picochess.ini
+        if email: # check if email address is provided by picochess.ini
             self.email = email
-        else: # if no email adress is set then set self.email to false so skip later sending the game as via mail
+        else: # if no email address is set then set self.email to false so skip later sending the game as via mail
             self.email = False
         # store information for SMTP based mail delivery
         self.smtp_server = fromIniSmtp_Server
@@ -52,7 +53,7 @@ class PgnDisplay(Display, threading.Thread):
 
     def run(self):
         while True:
-            #Check if we have something to display
+            # Check if we have something to display
             try:
                 message = self.message_queue.get()
                 if message == Message.GAME_ENDS and message.moves:
@@ -77,9 +78,9 @@ class PgnDisplay(Display, threading.Thread):
                         game.headers["Result"] = "0-1" if message.color == chess.WHITE else "1-0"
                     if message.mode == GameMode.PLAY_WHITE:
                         game.headers["White"] = self.email.split('@')[0] if self.email else 'Player'
-                        game.headers["Black"] = "PicoChess"
+                        game.headers["Black"] = self.engine_name
                     if message.mode == GameMode.PLAY_BLACK:
-                        game.headers["White"] = "PicoChess"
+                        game.headers["White"] = self.engine_name
                         game.headers["Black"] = self.email.split('@')[0] if self.email else 'Player'
                     # Save to file
                     file = open(self.file_name, "a")

--- a/picochess.ini.example
+++ b/picochess.ini.example
@@ -21,7 +21,7 @@
 ### ========================
 ### Options for the UCI-Chess engine
 ## What engine should play. Path to a UCI engine or Stockfish
-# engine = /opt/Stockfish/src/stockfish
+engine = stockfish
 ## uci-option stores options that will be passed to the engine
 # uci-option = Hash = 128
 # uci-option = Threads = 4

--- a/picochess.py
+++ b/picochess.py
@@ -85,6 +85,7 @@ def main():
     engine = uci.Engine(args.engine, hostname=args.remote, username=args.user, key_file=args.server_key, password=args.password)
 
     logging.debug('Loaded engine [%s]', engine.get().name)
+    engine_name = engine.get().name
     logging.debug('Supported options [%s]', engine.get().options)
     if 'Hash' in engine.get().options:
         engine.set_option("Hash", args.hash_size)
@@ -108,7 +109,7 @@ def main():
         TerminalDisplay().start()
 
     # Save to PGN
-    PgnDisplay(args.pgn_file, email=args.email, fromINIMailGun_Key=args.mailgun_key,
+    PgnDisplay(args.pgn_file, engine_name, email=args.email, fromINIMailGun_Key=args.mailgun_key,
                         fromIniSmtp_Server=args.smtp_server, fromINISmtp_User=args.smtp_user,
                         fromINISmtp_Pass=args.smtp_pass, fromINISmtp_Enc=args.smtp_encryption).start() 
 


### PR DESCRIPTION
Sometimes I play against another engine than Stockfish (recently compiled Arasan 17.5 for Raspberry Pi). This code proposal puts the engine name in the pgn output instead of just “PicoChess”.

To be able to change engines correctly, it was necessary to delete the -e option from /etc/init.d/picochess and instead use the engine option in picochess.ini.

The Arasan engine gets installed in the /usr/local/bin/Arasan-17.5.0 directory by default, so I created a symbolic link in /opt/picochess/engines. Now in picochess.ini it is enough to write engine = arasanx. 