### PR TITLE
Reboot Pi with clock button

### DIFF
--- a/dgt.py
+++ b/dgt.py
@@ -24,6 +24,7 @@ from timecontrol import *
 from struct import unpack
 from collections import OrderedDict
 from utilities import *
+from subprocess import Popen
 
 try:
     import enum
@@ -523,7 +524,8 @@ class DGTBoard(Observable, Display, threading.Thread):
                             self.fire(Event.SET_MODE, mode=mode_new)
 
                         if self.dgt_clock_menu == Menu.SETTINGS_MENU:
-                            self.display_on_dgt_clock('pic'+version)
+                            self.display_on_dgt_clock("reboot")
+                            subprocess.Popen(["sudo","reboot"])
 
                     if 65 <= message[4] <= 66 and message[5] == 53:
                         logging.info("Button 4 pressed")


### PR DESCRIPTION
When in SYSTEM mode, pressing the fourth clock button displays "REBOOT" on the clock and reboots the Raspberry Pi (see requests in issue #36 and issue #95). It's like pulling an emergency brake. Please be patient -- rebooting may take 35 seconds.

The fourth clock button previously showed the Picochess version number, but that is no longer needed: Pico always shows the version number at launch.