### PR TITLE
Make stockfish default engine

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -48,7 +48,7 @@ def display_system_info():
 def main():
     #Command line argument parsing
     parser = configargparse.ArgParser(default_config_files=[os.path.join(os.path.dirname(__file__), "picochess.ini")])
-    parser.add_argument("-e", "--engine", type=str, help="UCI engine executable path", required=True)
+    parser.add_argument("-e", "--engine", type=str, help="UCI engine executable path", default='stockfish')
     parser.add_argument("-d", "--dgt-port", type=str, help="enable dgt board on the given serial port such as /dev/ttyUSB0")
     parser.add_argument("-leds", "--enable-dgt-board-leds", action='store_true', help="enable dgt board leds")
     parser.add_argument("-hs", "--hash-size", type=int, help="hashtable size in MB (default:64)", default=64)

--- a/scripts/picochess.init
+++ b/scripts/picochess.init
@@ -29,7 +29,7 @@ case "$1" in
 
       echo $dgt_port
       cd /opt/picochess
-      screen -dmUS pc /opt/picochess/picochess.py -e stockfish -d $dgt_port -web -lf picochess.log -l debug -hs 128
+      screen -dmUS pc /opt/picochess/picochess.py -d $dgt_port -web -lf picochess.log -l debug -hs 128
     ;;
   stop)
     echo "Stopping picochess"


### PR DESCRIPTION
Makes stockfish the default engine. This fix solves the startup problem that occurs with the 0.43 image file, where picochess.py is started without the -e parameter and no engine is specified in picochess.ini.