### PR TITLE
Added Time Control to clock

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -141,11 +141,11 @@ class EngineMenu(AutoNumber):
 
 
 class TimeMenu(AutoNumber):
-    TIME_FIXED = ()  # Show last move
-    TIME__BLITZ = ()  # Show hint/evaluation
-    TIME_FISCHER = ()  # Starts/Stops the calculation
-    SPACER = ()  # Change Modes
-    SWITCH_MENU = ()  # Switch Menu
+    TIME_FIXED = () 
+    TIME__BLITZ = ()  
+    TIME_FISCHER = ()  
+    SPACER = ()  
+    SWITCH_MENU = ()  
 
 
 class GameMenu(AutoNumber):

--- a/utilities.py
+++ b/utilities.py
@@ -121,6 +121,7 @@ class Menu(AutoNumber):
     GAME_MENU = ()  # Default Menu
     SETUP_POSITION_MENU = ()  # Setup position menu
     ENGINE_MENU = ()  # Engine menu
+    TIME_MENU = () # Time controls menu
     SETTINGS_MENU = ()  # Settings menu
 
 
@@ -135,8 +136,15 @@ class SetupPositionMenu(AutoNumber):
 class EngineMenu(AutoNumber):
     LEVEL = ()
     BOOK = ()
-    TIME = ()
     ENG_INFO = ()
+    SWITCH_MENU = ()  # Switch Menu
+
+
+class TimeMenu(AutoNumber):
+    TIME_FIXED = ()  # Show last move
+    TIME__BLITZ = ()  # Show hint/evaluation
+    TIME_FISCHER = ()  # Starts/Stops the calculation
+    SPACER = ()  # Change Modes
     SWITCH_MENU = ()  # Switch Menu
 
 


### PR DESCRIPTION
* Time control may now be selected from the clock to further enhance game continuation or position setup
* There is a new 'time' menu option on the main menu
* While in the 'time' menu:
     Button 1 selects the time control type (Fixed, Blitz, Fischer etc)
     Button 3 displays the current time control setting
     Button 4 selects a new time control of the type selected or currently in use. Cycles though available options.
* Be aware that selecting a new time control will reset the clock time! Ideally use at the start of a game.

Also added engine status display
* While in the 'engine' menu, Button 3 will alternately display the engine playing level and the book in use.