### PR TITLE
Added Resign / Draw to DGT convention

### DIFF
--- a/libs/chesstalker/chesstalker.py
+++ b/libs/chesstalker/chesstalker.py
@@ -144,6 +144,15 @@ class ChessTalker(Display, threading.Thread):
                     elif message == Message.GAME_ENDS and message.result == GameResult.ABORT:
                         logging.debug('Announcing GAME_ENDS/ABORT')
                         system_voice.say_game_aborted()
+                    elif message == Message.GAME_ENDS and message.result == GameResult.DRAW:
+                        logging.debug('Announcing DRAW')
+                        system_voice.say_draw()
+                    elif message == Message.GAME_ENDS and message.result == GameResult.RESIGN_WHITE:
+                        logging.debug('Announcing WHITE WIN')
+                        system_voice.say_winner(ChessTalkerVoice.COLOR_WHITE)
+                    elif message == Message.GAME_ENDS and message.result == GameResult.RESIGN_BLACK:
+                        logging.debug('Announcing BLACK WIN')
+                        system_voice.say_winner(ChessTalkerVoice.COLOR_BLACK)
                 elif messageType == "Event":
                     if message == Event.SHUTDOWN:
                         logging.debug('Announcing SHUTDOWN')

--- a/pgn.py
+++ b/pgn.py
@@ -78,8 +78,11 @@ class PgnDisplay(Display, threading.Thread):
                     game.headers["Round"] = "?"
                     if message.result == GameResult.ABORT:
                         game.headers["Result"] = "*"
-                    elif message.result in (GameResult.STALEMATE, GameResult.SEVENTYFIVE_MOVES, GameResult.FIVEFOLD_REPETITION, GameResult.INSUFFICIENT_MATERIAL):
+                    elif message.result in (GameResult.DRAW, GameResult.STALEMATE, GameResult.SEVENTYFIVE_MOVES, 
+                        GameResult.FIVEFOLD_REPETITION, GameResult.INSUFFICIENT_MATERIAL):
                         game.headers["Result"] = "1/2-1/2"
+                    elif message.result in (GameResult.RESIGN_WHITE, GameResult.RESIGN_BLACK):
+                        game.headers["Result"] = "1-0" if message.result == GameResult.RESIGN_WHITE else "0-1"
                     elif message.result in (GameResult.MATE, GameResult.TIME_CONTROL):
                         game.headers["Result"] = "0-1" if message.color == chess.WHITE else "1-0"
 

--- a/utilities.py
+++ b/utilities.py
@@ -54,6 +54,7 @@ class Event(AutoNumber):
     FEN = ()  # User has moved one or more pieces, and we have a new fen position.
     LEVEL = ()  # User sets engine level (from 1 to 20).
     NEW_GAME = ()  # User starts a new game
+    DRAWRESIGN = () # User declares a resignation or draw
     USER_MOVE = ()  # User sends a move
     KEYBOARD_MOVE = ()  # Keyboard sends a move (to be transfered to a fen)
     OPENING_BOOK = ()  # User chooses an opening book
@@ -178,7 +179,7 @@ class ClockMode(AutoNumber):
     BLITZ = ()  # Fixed time per game
     FISCHER = ()  # Fischer increment
 
-
+@enum.unique
 class GameResult(enum.Enum):
     MATE = 'mate'
     STALEMATE = 'stalemate'
@@ -187,6 +188,9 @@ class GameResult(enum.Enum):
     SEVENTYFIVE_MOVES = '75 moves'
     FIVEFOLD_REPETITION = 'repetition'
     ABORT = 'abort'
+    RESIGN_WHITE = 'W wins'
+    RESIGN_BLACK = 'B wins'
+    DRAW = 'draw'
 
 
 class EngineStatus(AutoNumber):


### PR DESCRIPTION
Most games are resigned, but Pico requires a mate or records an abort, which is annoying if you upload your games to a database
of some sort for analysis.

Now, during a game, placing the two kings on opposite centre squares will signal a resignation:
* If both kings on white, the result is white wins and the game recorded 1-0
* If both kings on black, the result is black wins and the game recorded 0-1

Placing the kings on adjacent centre squares on the same rank signals a draw and the game recorded 1/2-1/2.

The 4 and 5 rank must be clear of other pieces - only kings.

It's your decision when to declare a win or draw - be honest with yourself about whether you would have drawn
or lost :)