### PR TITLE
Better debian package is virtualenv

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,7 +108,7 @@ Manual installation
 
   Virtualenv provides clean and isolated development environments for your
   Python projects (``pip3 install virtualenv`` or
-  ``apt-get install python3-virtualenv``).
+  ``apt-get install virtualenv``).
 
   Initialize a new environment: ``virtualenv -p python3 venv``
 


### PR DESCRIPTION
Fixup for the recent update to the installation instructions: `virtualenv` is the recommended package that Debian users should install.