### PR TITLE
Add log message when starting new engine

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -546,6 +546,8 @@ def main():
                         # Restore options - this doesn't deal with any
                         # supplementary uci options sent 'in game', see event.UCI_OPTION_SET
                         engine_startup()
+                        logging.debug('Loaded engine [%s]', engine_name)
+                        logging.debug('Supported options [%s]', engine.get().options)
                         # Send user selected engine level to new engine
                         if engine_level and engine.level(engine_level):
                             engine.send()


### PR DESCRIPTION
When the users starts a new engine, this event is reported in the log file. Two log messages contain the name of the new engine and its option list, just like the two log messages at startup.