### PR TITLE
Fix unreliable bluetooth board detection

### DIFF
--- a/dgt/board.py
+++ b/dgt/board.py
@@ -539,6 +539,8 @@ class DgtBoard(object):
                     pass
                 elif 'Changing power on succeeded' in self.bt_line:
                     self.bt_state = 1
+                    self.btctl.stdin.write("devices\n")
+                    self.btctl.stdin.flush()                    
                     self.btctl.stdin.write("agent on\n")
                     self.btctl.stdin.flush()
                 elif 'Agent registered' in self.bt_line:
@@ -568,14 +570,16 @@ class DgtBoard(object):
                     self.bt_name_list.remove(self.bt_name_list[self.bt_current_device])
                     self.bt_current_device -= 1
                     logging.debug('BT pairing failed, unknown device')
-                elif ('DGT_BT_' in self.bt_line or 'PCS-REVII' in self.bt_line) and \
-                        ('NEW' in self.bt_line or 'CHG' in self.bt_line) and 'Device' in self.bt_line:
-                    # New e-Board found add to list
+                elif ('DGT_BT_' in self.bt_line or 'PCS-REVII' in self.bt_line):
+                    offset = 3
+                    if ('NEW' not in self.bt_line and 'CHG' not in self.bt_line) and 'Device' in self.bt_line:
+                        offset = 1
+                    # e-Board found add to list
                     try:
-                        if not self.bt_line.split()[3] in self.bt_mac_list:
-                            self.bt_mac_list.append(self.bt_line.split()[3])
-                            self.bt_name_list.append(self.bt_line.split()[4])
-                            logging.debug('BT found device: %s %s', self.bt_line.split()[3], self.bt_line.split()[4])
+                        if not self.bt_line.split()[offset] in self.bt_mac_list:
+                            self.bt_mac_list.append(self.bt_line.split()[offset])
+                            self.bt_name_list.append(self.bt_line.split()[offset+1])
+                            logging.debug('BT found device: %s %s', self.bt_line.split()[offset], self.bt_line.split()[offset+1])
                     except IndexError:
                         logging.error('BT wrong line [%s]', self.bt_line)
                 # clear the line


### PR DESCRIPTION
bluetoothctl may already have discovered some devices before this code segment. Causing them never to show as NEW or CHG or not to show for a long time. Adds a look for any existing known devices to pick them up.